### PR TITLE
Fix for 'no writecb in Transform' error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,9 @@ module.exports = function (options) {
         }, options.rootDir, function (success) {
             if(!success) {
                 cb(new gutil.PluginError('gulp-jest', { message: "Tests Failed" }));
+            } else {
+                cb();
             }
-            cb();
         }.bind(this));
     });
 };


### PR DESCRIPTION
The clue came from the discussion here:
https://github.com/rvagg/through2/issues/1

Reproducing:

I'm using gulp-notify to log errors:

```
return gulp
  .src('__tests__')
  .pipe(plumber())
  .on("error", notifyError("Jest Error"))
  .pipe(jest(packagejson.jest));
```

This simply might have made the error visible. If a test failed, the callback would be invoked twice.
