### PR TITLE
fix `options.rootDir` problem

### DIFF
--- a/__tests__/fixture.js
+++ b/__tests__/fixture.js
@@ -1,6 +1,6 @@
 describe('fixture', function () {
 	it('should pass', function () {
-		console.log()
+		console.log();
 		expect(1 + 2).toEqual(3);
 	});
 });

--- a/index.js
+++ b/index.js
@@ -7,12 +7,12 @@ var jest = require('jest-cli'),
 module.exports = function (options) {
     options = options || {};
     return through.obj(function (file, enc, cb) {
-        options.rootDir = options.rootDir || file.path;
+        options.rootDir = file.path;
         jest.runCLI({
             config: options
         }, options.rootDir, function (success) {
             if(!success) {
-                cb(new gutil.PluginError('gulp-jest', { message: "Tests Failed" }));
+                cb(new gutil.PluginError('gulp-jest', { message: 'Tests Failed' }));
             } else {
                 cb();
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jest",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Gulp plugin for running your Jest tests",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -6,39 +6,18 @@ var jest = require('./index');
 var through2 = require('through2');
 var out = process.stdout.write.bind(process.stdout);
 
-it('should take a rootDir as an option', function (cb) {
-    var stream = jest({
-        rootDir: '__tests__'
+describe('gulp-jest', function () {
+    it('should use the scream path as the rootDir', function (cb) {
+        var stream = gulp.src('__tests__')
+            .pipe(jest());
+
+        process.stdout.write = function (str) {
+            out(str);
+            if (/test passed/.test(str)) {
+                assert(true);
+                process.stdout.write = out;
+                cb();
+            }
+        };
     });
-
-    process.stdout.write = function (str) {
-        out(str);
-        if (/test passed/.test(str)) {
-            assert(true);
-            process.stdout.write = out;
-            cb();
-        }
-    };
-
-    stream.write(new gutil.File({
-        path: '__tests__',
-        contents: new Buffer('')
-    }));
-
-    stream.end();
-});
-
-
-it('should use the scream path as the rootDir', function (cb) {
-    var stream = gulp.src('__tests__')
-        .pipe(jest());
-
-    process.stdout.write = function (str) {
-        out(str);
-        if (/test passed/.test(str)) {
-            assert(true);
-            process.stdout.write = out;
-            cb();
-        }
-    };
 });


### PR DESCRIPTION
When I don't define `optoins.rootDir` in options, such as:

```js
gulp.task('jest', function () {
  var nodeModules = path.resolve('./node_modules');

  return gulp.src('app/scripts/**/__tests__')
    .pipe($.jest({
        scriptPreprocessor: nodeModules + '/gulp-jest/preprocessor.js',
        unmockedModulePathPatterns: [nodeModules + '/react']
    }));
});
```

When in `scripts` dir, It have more than one `__tests__` dir, such as `scripts/dropdown/__tests__` and `scripts/nav/__tests__`, the `options.rootDir`
 always be `scripts/dropdown/__tests__`, and will test `scripts/dropdown/__tests__` twice。

![gulp-jest](http://cookfront.qiniudn.com/gulp-jest.png)

I think `gulp.src` have defined test dir,  and need not define `options.rootDir`, So I think set the `options.rootDir` always be `file.path`

```js
options.rootDir = file.path;
```