### PR TITLE
Add ability to handle multiple files

### DIFF
--- a/__tests__/fixture2.js
+++ b/__tests__/fixture2.js
@@ -1,0 +1,6 @@
+describe('fixture', function () {
+	it('should pass too', function () {
+		console.log()
+		expect(1 + 2).toEqual(3);
+	});
+});

--- a/index.js
+++ b/index.js
@@ -7,10 +7,15 @@ var jest = require('jest-cli'),
 module.exports = function (options) {
     options = options || {};
     return through.obj(function (file, enc, cb) {
-        options.rootDir = options.rootDir || file.path;
-        jest.runCLI({
-            config: options
-        }, options.rootDir, function (success) {
+        var args = {};
+        if(file.isDirectory()) {
+          options.rootDir = options.rootDir || file.path;
+        } else {
+          options.rootDir = options.rootDir;
+          args._ = [file.path];
+        }
+        args.config = options;
+        jest.runCLI(args, options.rootDir, function (success) {
             if(!success) {
                 cb(new gutil.PluginError('gulp-jest', { message: "Tests Failed" }));
             } else {

--- a/test.js
+++ b/test.js
@@ -57,5 +57,5 @@ it('should handle multiple files passed', function(cb) {
     setTimeout(function() {
       assert.equal(numberOfOccurences, 2);
       cb();
-    }, 3000);
+    }, 7000);
 });

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ it('should take a rootDir as an option', function (cb) {
 
     process.stdout.write = function (str) {
         out(str);
-        if (/test passed/.test(str)) {
+        if (/test(s)? passed/.test(str)) {
             assert(true);
             process.stdout.write = out;
             cb();
@@ -35,10 +35,27 @@ it('should use the scream path as the rootDir', function (cb) {
 
     process.stdout.write = function (str) {
         out(str);
-        if (/test passed/.test(str)) {
+        if (/test(s)? passed/.test(str)) {
             assert(true);
             process.stdout.write = out;
             cb();
         }
     };
+});
+
+it('should handle multiple files passed', function(cb) {
+    var stream = gulp.src('__tests__/*.js')
+        .pipe(jest({rootDir: process.cwd()}));
+
+    var numberOfOccurences = 0;
+    process.stdout.write = function (str) {
+        out(str);
+        if (/test passed/.test(str)) {
+          numberOfOccurences += 1;
+        }
+    };
+    setTimeout(function() {
+      assert.equal(numberOfOccurences, 2);
+      cb();
+    }, 3000);
 });


### PR DESCRIPTION
It's quite confusing (https://github.com/Dakuan/gulp-jest/issues/14 for example) that this plugin cannot handle gulp.src which outputs list of files and not a directory. 
I've added a very simple way to handle multiple files by using jest regex patch matching. 