### PR TITLE
Added note about process.env.NODE_ENV to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Unlike the `jest` CLI tool, `gulp-jest` does not automatically set `process.env.
 to be `test`. If you are using Webpack or Babel, you may need to manually set `process.env.NODE_ENV`
 prior to running the task itself.
 
-```
+```javascript
 gulp.task('jest', function () {
   process.env.NODE_ENV = 'test';
   

--- a/README.md
+++ b/README.md
@@ -30,13 +30,29 @@ gulp.task('jest', function () {
 
 ```
 
+## `process.env.NODE_ENV`
+
+Unlike the `jest` CLI tool, `gulp-jest` does not automatically set `process.env.NODE_ENV` 
+to be `test`. If you are using Webpack or Babel, you may need to manually set `process.env.NODE_ENV`
+prior to running the task itself.
+
+```
+gulp.task('jest', function () {
+  process.env.NODE_ENV = 'test';
+  
+  return gulp.src('__tests__').pipe(jest({
+    ...
+  }));
+});
+```
+
 ## API
 
 ### jest(options)
 
 #### options
 
-as per [Jest config](http://facebook.github.io/jest/docs/api.html#config-options)
+as per [Jest config](http://facebook.github.io/jest/docs/configuration.html)
 
 ## License
 


### PR DESCRIPTION
Spent a day trying to get `gulp-jest` to work. I didn't realize that `process.env.NODE_ENV` wasn't being set to `test` like it is when running `jest` from the command line, as mentioned [here](http://facebook.github.io/jest/docs/getting-started.html#using-babel). This caused a lot of confusion and lost time for me so I figured adding a note to that effect could help others.