### PR TITLE
Fixing the use of vinyl sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,28 @@ gulp.task('jest', function () {
 
 ```
 
+Or, use vinyl sources with gulp:
+
+```javascript
+var jest = require('gulp-jest').default;
+
+gulp.task('jest', function () {
+  return gulp.src('tests/**/*.my-tests.js').pipe(jest());
+});
+```
+
+
+
 ## `process.env.NODE_ENV`
 
-Unlike the `jest` CLI tool, `gulp-jest` does not automatically set `process.env.NODE_ENV` 
+Unlike the `jest` CLI tool, `gulp-jest` does not automatically set `process.env.NODE_ENV`
 to be `test`. If you are using Webpack or Babel, you may need to manually set `process.env.NODE_ENV`
 prior to running the task itself.
 
 ```javascript
 gulp.task('jest', function () {
   process.env.NODE_ENV = 'test';
-  
+
   return gulp.src('__tests__').pipe(jest({
     ...
   }));

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -17,6 +17,16 @@ it('should pass a test', (done) => {
     .on('finish', () => done());
 });
 
+it('should pass a test passed from gulp', (done) => {
+  gulp.src('fixture-pass/*-test.js')
+    .pipe(jest())
+    .on('error', (error) => {
+      fail('Test should not fail', error);
+      done();
+    })
+    .on('finish', () => done());
+});
+
 it('should fail a test', (done) => {
   gulp.src('__tests__')
     .pipe(jest({

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "homepage": "https://github.com/alansouzati/gulp-jest",
   "dependencies": {
     "gulp-util": "^3.0.0",
+    "lodash.defaultsdeep": "^4.6.0",
     "through2": "^2.0.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,14 @@
 import jest from 'jest-cli';
 import gutil from 'gulp-util';
 import through2 from 'through2';
+import defaultsDeep from 'lodash.defaultsdeep';
 
-export default (options = {}) => {
+export default (defaultOptions = {}) => {
   return through2.obj((file, enc, cb) => {
-    options = Object.assign({}, options, {
-      config: Object.assign({
-        rootDir: file ? file.path : undefined
-      }, options.config)
-    });
+    // Allow for '__tests__' to just use current cwd.
+    let options = defaultsDeep({}, { config: {
+      rootDir: file && !file.path.match(/.*__tests__/i) ? file.path : undefined
+    }}, defaultOptions);
 
     jest.runCLI(options, [options.config.rootDir], (result) => {
       if(result.numFailedTests || result.numFailedTestSuites) {


### PR DESCRIPTION
Currently, the way this modules handle vinyl files (`gulp.src`), the original options were getting passed as reference and `Object.assign` was not circumventing it, which led to the same test getting called multiple times.  This fixes it.