### PR TITLE
Add `config` to options

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ gulp.task('jest', function () {
   process.env.NODE_ENV = 'test';
   
   return gulp.src('__tests__').pipe(jest({
-    ...
+    config: { ... }
   }));
 });
 ```


### PR DESCRIPTION
If config object passed to gulp-jest doesn't have a top-level `config` property, the config will be silently ignored.